### PR TITLE
feature: Use curve25519-voi

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -95,6 +95,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [statesync] \#6566 Allow state sync fetchers and request timeout to be configurable. (@alexanderbez)
 - [types] \#6478 Add `block_id` to `newblock` event (@jeebster)
 - [crypto/ed25519] \#5632 Adopt zip215 `ed25519` verification. (@marbar3778)
+- [crypto/ed25519] \#6526 Use [curve25519-voi](https://github.com/oasisprotocol/curve25519-voi) for `ed25519` signing and verification. (@Yawning)
 - [privval] \#5603 Add `--key` to `init`, `gen_validator`, `testnet` & `unsafe_reset_priv_validator` for use in generating `secp256k1` keys.
 - [privval] \#5725 Add gRPC support to private validator.
 - [privval] \#5876 `tendermint show-validator` will query the remote signer if gRPC is being used (@marbar3778)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -62,6 +62,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
   - [mempool] \#6466 The original mempool reactor has been versioned as `v0` and moved to a sub-package under the root `mempool` package.
     Some core types have been kept in the `mempool` package such as `TxCache` and it's implementations, the `Mempool` interface itself
     and `TxInfo`. (@alexanderbez)
+  - [crypto/sr25519] \#6526 Do not re-execute the Ed25519-style key derivation step when doing signing and verification.  The derivation is now done once and only once.  This breaks `sr25519.GenPrivKeyFromSecret` output compatibility. (@Yawning)
 
 - Blockchain Protocol
 
@@ -96,6 +97,7 @@ Friendly reminder: We have a [bug bounty program](https://hackerone.com/tendermi
 - [types] \#6478 Add `block_id` to `newblock` event (@jeebster)
 - [crypto/ed25519] \#5632 Adopt zip215 `ed25519` verification. (@marbar3778)
 - [crypto/ed25519] \#6526 Use [curve25519-voi](https://github.com/oasisprotocol/curve25519-voi) for `ed25519` signing and verification. (@Yawning)
+- [crypto/sr25519] \#6526 Use [curve25519-voi](https://github.com/oasisprotocol/curve25519-voi) for `sr25519` signing and verification. (@Yawning)
 - [privval] \#5603 Add `--key` to `init`, `gen_validator`, `testnet` & `unsafe_reset_priv_validator` for use in generating `secp256k1` keys.
 - [privval] \#5725 Add gRPC support to private validator.
 - [privval] \#5876 `tendermint show-validator` will query the remote signer if gRPC is being used (@marbar3778)

--- a/crypto/batch/batch.go
+++ b/crypto/batch/batch.go
@@ -20,3 +20,14 @@ func CreateBatchVerifier(pk crypto.PubKey) (crypto.BatchVerifier, bool) {
 	// case where the key does not support batch verification
 	return nil, false
 }
+
+// SupportsBatchVerifier checks if a key type implements the batch verifier
+// interface.
+func SupportsBatchVerifier(pk crypto.PubKey) bool {
+	switch pk.Type() {
+	case ed25519.KeyType, sr25519.KeyType:
+		return true
+	}
+
+	return false
+}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -46,7 +46,9 @@ type Symmetric interface {
 type BatchVerifier interface {
 	// Add appends an entry into the BatchVerifier.
 	Add(key PubKey, message, signature []byte) error
-	// Verify verifies all the entries in the BatchVerifier.
-	// If the verification fails it is unknown which entry failed and each entry will need to be verified individually.
-	Verify() bool
+	// Verify verifies all the entries in the BatchVerifier, and returns
+	// if every signature in the batch is valid, and a vector of bools
+	// indicating the verification status of each signature (in the order
+	// that signatures were added to the batch).
+	Verify() (bool, []bool)
 }

--- a/crypto/ed25519/bench_test.go
+++ b/crypto/ed25519/bench_test.go
@@ -28,21 +28,36 @@ func BenchmarkVerification(b *testing.B) {
 }
 
 func BenchmarkVerifyBatch(b *testing.B) {
+	msg := []byte("BatchVerifyTest")
+
 	for _, sigsCount := range []int{1, 8, 64, 1024} {
 		sigsCount := sigsCount
 		b.Run(fmt.Sprintf("sig-count-%d", sigsCount), func(b *testing.B) {
-			b.ReportAllocs()
-			v := NewBatchVerifier()
+			// Pre-generate all of the keys, and signatures, but do not
+			// benchmark key-generation and signing.
+			pubs := make([]crypto.PubKey, 0, sigsCount)
+			sigs := make([][]byte, 0, sigsCount)
 			for i := 0; i < sigsCount; i++ {
 				priv := GenPrivKey()
-				pub := priv.PubKey()
-				msg := []byte("BatchVerifyTest")
 				sig, _ := priv.Sign(msg)
-				err := v.Add(pub, msg, sig)
-				require.NoError(b, err)
+				pubs = append(pubs, priv.PubKey().(PubKey))
+				sigs = append(sigs, sig)
 			}
+			b.ResetTimer()
+
+			b.ReportAllocs()
 			// NOTE: dividing by n so that metrics are per-signature
 			for i := 0; i < b.N/sigsCount; i++ {
+				// The benchmark could just benchmark the Verify()
+				// routine, but there is non-trivial overhead associated
+				// with BatchVerifier.Add(), which should be included
+				// in the benchmark.
+				v := NewBatchVerifier()
+				for i := 0; i < sigsCount; i++ {
+					err := v.Add(pubs[i], msg, sigs[i])
+					require.NoError(b, err)
+				}
+
 				if !v.Verify() {
 					b.Fatal("signature set failed batch verification")
 				}

--- a/crypto/ed25519/bench_test.go
+++ b/crypto/ed25519/bench_test.go
@@ -58,7 +58,7 @@ func BenchmarkVerifyBatch(b *testing.B) {
 					require.NoError(b, err)
 				}
 
-				if !v.Verify() {
+				if ok, _ := v.Verify(); !ok {
 					b.Fatal("signature set failed batch verification")
 				}
 			}

--- a/crypto/ed25519/ed25519_test.go
+++ b/crypto/ed25519/ed25519_test.go
@@ -50,5 +50,6 @@ func TestBatchSafe(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.True(t, v.Verify())
+	ok, _ := v.Verify()
+	require.True(t, ok)
 }

--- a/crypto/sr25519/batch.go
+++ b/crypto/sr25519/batch.go
@@ -8,19 +8,31 @@ import (
 	"github.com/tendermint/tendermint/crypto"
 )
 
-var _ crypto.BatchVerifier = BatchVerifier{}
+var _ crypto.BatchVerifier = &BatchVerifier{}
 
 // BatchVerifier implements batch verification for sr25519.
 // https://github.com/ChainSafe/go-schnorrkel is used for batch verification
 type BatchVerifier struct {
 	*schnorrkel.BatchVerifier
+
+	// The go-schnorrkel API is terrible for performance if the chance
+	// that a batch fails is non-negligible, exact information about
+	// which signature failed is something that is desired, and the
+	// system is not resource constrained.
+	//
+	// The tendermint case meets all of the criteria, so emulate a
+	// one-shot with fallback API so that libraries that do provide
+	// sensible behavior aren't penalized.
+	pubKeys    []crypto.PubKey
+	messages   [][]byte
+	signatures [][]byte
 }
 
 func NewBatchVerifier() crypto.BatchVerifier {
-	return BatchVerifier{schnorrkel.NewBatchVerifier()}
+	return &BatchVerifier{schnorrkel.NewBatchVerifier(), nil, nil, nil}
 }
 
-func (b BatchVerifier) Add(key crypto.PubKey, msg, sig []byte) error {
+func (b *BatchVerifier) Add(key crypto.PubKey, msg, sig []byte) error {
 	var sig64 [SignatureSize]byte
 	copy(sig64[:], sig)
 	signature := new(schnorrkel.Signature)
@@ -34,9 +46,40 @@ func (b BatchVerifier) Add(key crypto.PubKey, msg, sig []byte) error {
 	var pk [PubKeySize]byte
 	copy(pk[:], key.Bytes())
 
-	return b.BatchVerifier.Add(signingContext, signature, schnorrkel.NewPublicKey(pk))
+	err = b.BatchVerifier.Add(signingContext, signature, schnorrkel.NewPublicKey(pk))
+	if err == nil {
+		b.pubKeys = append(b.pubKeys, key)
+		b.messages = append(b.messages, msg)
+		b.signatures = append(b.signatures, sig)
+	}
+
+	return err
 }
 
-func (b BatchVerifier) Verify() bool {
-	return b.BatchVerifier.Verify()
+func (b *BatchVerifier) Verify() (bool, []bool) {
+	// Explicitly mimic ed25519consensus/curve25519-voi behavior.
+	if len(b.pubKeys) == 0 {
+		return false, nil
+	}
+
+	// Optimistically assume everything will succeed.
+	valid := make([]bool, len(b.pubKeys))
+	for i := range valid {
+		valid[i] = true
+	}
+
+	// Fast path, every signature may be valid.
+	if b.BatchVerifier.Verify() {
+		return true, valid
+	}
+
+	// Fall-back to serial verification.
+	allValid := true
+	for i := range b.pubKeys {
+		pk, msg, sig := b.pubKeys[i], b.messages[i], b.signatures[i]
+		valid[i] = pk.VerifySignature(msg, sig)
+		allValid = allValid && valid[i]
+	}
+
+	return allValid, valid
 }

--- a/crypto/sr25519/bench_test.go
+++ b/crypto/sr25519/bench_test.go
@@ -28,21 +28,36 @@ func BenchmarkVerification(b *testing.B) {
 }
 
 func BenchmarkVerifyBatch(b *testing.B) {
-	for _, n := range []int{1, 8, 64, 1024} {
-		n := n
-		b.Run(fmt.Sprintf("sig-count-%d", n), func(b *testing.B) {
-			b.ReportAllocs()
-			v := NewBatchVerifier()
-			for i := 0; i < n; i++ {
+	msg := []byte("BatchVerifyTest")
+
+	for _, sigsCount := range []int{1, 8, 64, 1024} {
+		sigsCount := sigsCount
+		b.Run(fmt.Sprintf("sig-count-%d", sigsCount), func(b *testing.B) {
+			// Pre-generate all of the keys, and signatures, but do not
+			// benchmark key-generation and signing.
+			pubs := make([]crypto.PubKey, 0, sigsCount)
+			sigs := make([][]byte, 0, sigsCount)
+			for i := 0; i < sigsCount; i++ {
 				priv := GenPrivKey()
-				pub := priv.PubKey()
-				msg := []byte("BatchVerifyTest")
 				sig, _ := priv.Sign(msg)
-				err := v.Add(pub, msg, sig)
-				require.NoError(b, err)
+				pubs = append(pubs, priv.PubKey().(PubKey))
+				sigs = append(sigs, sig)
 			}
+			b.ResetTimer()
+
+			b.ReportAllocs()
 			// NOTE: dividing by n so that metrics are per-signature
-			for i := 0; i < b.N/n; i++ {
+			for i := 0; i < b.N/sigsCount; i++ {
+				// The benchmark could just benchmark the Verify()
+				// routine, but there is non-trivial overhead associated
+				// with BatchVerifier.Add(), which should be included
+				// in the benchmark.
+				v := NewBatchVerifier()
+				for i := 0; i < sigsCount; i++ {
+					err := v.Add(pubs[i], msg, sigs[i])
+					require.NoError(b, err)
+				}
+
 				if ok, _ := v.Verify(); !ok {
 					b.Fatal("signature set failed batch verification")
 				}

--- a/crypto/sr25519/bench_test.go
+++ b/crypto/sr25519/bench_test.go
@@ -43,7 +43,7 @@ func BenchmarkVerifyBatch(b *testing.B) {
 			}
 			// NOTE: dividing by n so that metrics are per-signature
 			for i := 0; i < b.N/n; i++ {
-				if !v.Verify() {
+				if ok, _ := v.Verify(); !ok {
 					b.Fatal("signature set failed batch verification")
 				}
 			}

--- a/crypto/sr25519/encoding.go
+++ b/crypto/sr25519/encoding.go
@@ -1,23 +1,13 @@
 package sr25519
 
-import (
-	"github.com/tendermint/tendermint/crypto"
-	tmjson "github.com/tendermint/tendermint/libs/json"
-)
-
-var _ crypto.PrivKey = PrivKey{}
+import tmjson "github.com/tendermint/tendermint/libs/json"
 
 const (
 	PrivKeyName = "tendermint/PrivKeySr25519"
 	PubKeyName  = "tendermint/PubKeySr25519"
-
-	// SignatureSize is the size of an Edwards25519 signature. Namely the size of a compressed
-	// Sr25519 point, and a field element. Both of which are 32 bytes.
-	SignatureSize = 64
 )
 
 func init() {
-
 	tmjson.RegisterType(PubKey{}, PubKeyName)
 	tmjson.RegisterType(PrivKey{}, PrivKeyName)
 }

--- a/crypto/sr25519/privkey.go
+++ b/crypto/sr25519/privkey.go
@@ -1,76 +1,128 @@
 package sr25519
 
 import (
-	"crypto/subtle"
+	"encoding/json"
 	"fmt"
 	"io"
 
-	"github.com/tendermint/tendermint/crypto"
+	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
 
-	schnorrkel "github.com/ChainSafe/go-schnorrkel"
+	"github.com/tendermint/tendermint/crypto"
 )
 
-// PrivKeySize is the number of bytes in an Sr25519 private key.
-const PrivKeySize = 32
+var (
+	_ crypto.PrivKey = PrivKey{}
 
-// PrivKeySr25519 implements crypto.PrivKey.
-type PrivKey []byte
+	signingCtx = sr25519.NewSigningContext([]byte{})
+)
 
-// Bytes returns the byte representation of the PrivKey.
+const (
+	// PrivKeySize is the size of a sr25519 signature in bytes.
+	PrivKeySize = sr25519.MiniSecretKeySize
+
+	KeyType = "sr25519"
+)
+
+// PrivKey implements crypto.PrivKey.
+type PrivKey struct {
+	msk sr25519.MiniSecretKey
+	kp  *sr25519.KeyPair
+}
+
+// Bytes returns the byte-encoded PrivKey.
 func (privKey PrivKey) Bytes() []byte {
-	return []byte(privKey)
+	if privKey.kp == nil {
+		return nil
+	}
+	return privKey.msk[:]
 }
 
 // Sign produces a signature on the provided message.
 func (privKey PrivKey) Sign(msg []byte) ([]byte, error) {
-	var p [PrivKeySize]byte
-	copy(p[:], privKey)
-	miniSecretKey, err := schnorrkel.NewMiniSecretKeyFromRaw(p)
-	if err != nil {
-		return []byte{}, err
-	}
-	secretKey := miniSecretKey.ExpandEd25519()
-
-	signingContext := schnorrkel.NewSigningContext([]byte{}, msg)
-
-	sig, err := secretKey.Sign(signingContext)
-	if err != nil {
-		return []byte{}, err
+	if privKey.kp == nil {
+		return nil, fmt.Errorf("sr25519: uninitialized private key")
 	}
 
-	sigBytes := sig.Encode()
-	return sigBytes[:], nil
+	st := signingCtx.NewTranscriptBytes(msg)
+
+	sig, err := privKey.kp.Sign(crypto.CReader(), st)
+	if err != nil {
+		return nil, fmt.Errorf("sr25519: failed to sign message: %w", err)
+	}
+
+	sigBytes, err := sig.MarshalBinary()
+	if err != nil {
+		return nil, fmt.Errorf("sr25519: failed to serialize signature: %w", err)
+	}
+
+	return sigBytes, nil
 }
 
 // PubKey gets the corresponding public key from the private key.
+//
+// Panics if the private key is not initialized.
 func (privKey PrivKey) PubKey() crypto.PubKey {
-	var p [PrivKeySize]byte
-	copy(p[:], privKey)
-	miniSecretKey, err := schnorrkel.NewMiniSecretKeyFromRaw(p)
-	if err != nil {
-		panic(fmt.Sprintf("Invalid private key: %v", err))
+	if privKey.kp == nil {
+		panic("sr25519: uninitialized private key")
 	}
-	secretKey := miniSecretKey.ExpandEd25519()
 
-	pubkey, err := secretKey.Public()
+	b, err := privKey.kp.PublicKey().MarshalBinary()
 	if err != nil {
-		panic(fmt.Sprintf("Could not generate public key: %v", err))
+		panic("sr25519: failed to serialize public key: " + err.Error())
 	}
-	key := pubkey.Encode()
-	return PubKey(key[:])
+
+	return PubKey(b)
 }
 
 // Equals - you probably don't need to use this.
 // Runs in constant time based on length of the keys.
 func (privKey PrivKey) Equals(other crypto.PrivKey) bool {
-	if otherEd, ok := other.(PrivKey); ok {
-		return subtle.ConstantTimeCompare(privKey[:], otherEd[:]) == 1
+	if otherSr, ok := other.(PrivKey); ok {
+		return privKey.msk.Equal(&otherSr.msk)
 	}
 	return false
 }
 
 func (privKey PrivKey) Type() string {
 	return KeyType
+}
+
+func (privKey PrivKey) MarshalJSON() ([]byte, error) {
+	var b []byte
+
+	// Handle uninitialized private keys gracefully.
+	if privKey.kp != nil {
+		b = privKey.Bytes()
+	}
+
+	return json.Marshal(b)
+}
+
+func (privKey *PrivKey) UnmarshalJSON(data []byte) error {
+	for i := range privKey.msk {
+		privKey.msk[i] = 0
+	}
+	privKey.kp = nil
+
+	var b []byte
+	if err := json.Unmarshal(data, &b); err != nil {
+		return fmt.Errorf("sr25519: failed to deserialize JSON: %w", err)
+	}
+	if len(b) == 0 {
+		return nil
+	}
+
+	msk, err := sr25519.NewMiniSecretKeyFromBytes(b)
+	if err != nil {
+		return err
+	}
+
+	sk := msk.ExpandEd25519()
+
+	privKey.msk = *msk
+	privKey.kp = sk.KeyPair()
+
+	return nil
 }
 
 // GenPrivKey generates a new sr25519 private key.
@@ -80,20 +132,18 @@ func GenPrivKey() PrivKey {
 	return genPrivKey(crypto.CReader())
 }
 
-// genPrivKey generates a new sr25519 private key using the provided reader.
-func genPrivKey(rand io.Reader) PrivKey {
-	var seed [64]byte
-
-	out := make([]byte, 64)
-	_, err := io.ReadFull(rand, out)
+func genPrivKey(rng io.Reader) PrivKey {
+	msk, err := sr25519.GenerateMiniSecretKey(rng)
 	if err != nil {
-		panic(err)
+		panic("sr25519: failed to generate MiniSecretKey: " + err.Error())
 	}
 
-	copy(seed[:], out)
+	sk := msk.ExpandEd25519()
 
-	key := schnorrkel.NewMiniSecretKey(seed).ExpandEd25519().Encode()
-	return key[:]
+	return PrivKey{
+		msk: *msk,
+		kp:  sk.KeyPair(),
+	}
 }
 
 // GenPrivKeyFromSecret hashes the secret with SHA2, and uses
@@ -102,9 +152,14 @@ func genPrivKey(rand io.Reader) PrivKey {
 // if it's derived from user input.
 func GenPrivKeyFromSecret(secret []byte) PrivKey {
 	seed := crypto.Sha256(secret) // Not Ripemd160 because we want 32 bytes.
-	var bz [PrivKeySize]byte
-	copy(bz[:], seed)
-	privKey, _ := schnorrkel.NewMiniSecretKeyFromRaw(bz)
-	key := privKey.ExpandEd25519().Encode()
-	return key[:]
+
+	var privKey PrivKey
+	if err := privKey.msk.UnmarshalBinary(seed); err != nil {
+		panic("sr25519: failed to deserialize MiniSecretKey: " + err.Error())
+	}
+
+	sk := privKey.msk.ExpandEd25519()
+	privKey.kp = sk.KeyPair()
+
+	return privKey
 }

--- a/crypto/sr25519/pubkey.go
+++ b/crypto/sr25519/pubkey.go
@@ -4,74 +4,65 @@ import (
 	"bytes"
 	"fmt"
 
+	"github.com/oasisprotocol/curve25519-voi/primitives/sr25519"
+
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/tmhash"
-
-	schnorrkel "github.com/ChainSafe/go-schnorrkel"
 )
 
 var _ crypto.PubKey = PubKey{}
 
-// PubKeySize is the number of bytes in an Sr25519 public key.
 const (
-	PubKeySize = 32
-	KeyType    = "sr25519"
+	// PubKeySize is the size of a sr25519 public key in bytes.
+	PubKeySize = sr25519.PublicKeySize
+
+	// SignatureSize is the size of a sr25519 signature in bytes.
+	SignatureSize = sr25519.SignatureSize
 )
 
-// PubKeySr25519 implements crypto.PubKey for the Sr25519 signature scheme.
+// PubKey implements crypto.PubKey.
 type PubKey []byte
 
 // Address is the SHA256-20 of the raw pubkey bytes.
 func (pubKey PubKey) Address() crypto.Address {
-	return crypto.Address(tmhash.SumTruncated(pubKey[:]))
+	if len(pubKey) != PubKeySize {
+		panic("pubkey is incorrect size")
+	}
+	return crypto.Address(tmhash.SumTruncated(pubKey))
 }
 
-// Bytes returns the byte representation of the PubKey.
+// Bytes returns the PubKey byte format.
 func (pubKey PubKey) Bytes() []byte {
 	return []byte(pubKey)
 }
 
-func (pubKey PubKey) VerifySignature(msg []byte, sig []byte) bool {
-	// make sure we use the same algorithm to sign
-	if len(sig) != SignatureSize {
-		return false
-	}
-	var sig64 [SignatureSize]byte
-	copy(sig64[:], sig)
-
-	publicKey := &(schnorrkel.PublicKey{})
-	var p [PubKeySize]byte
-	copy(p[:], pubKey)
-	err := publicKey.Decode(p)
-	if err != nil {
-		return false
-	}
-
-	signingContext := schnorrkel.NewSigningContext([]byte{}, msg)
-
-	signature := &(schnorrkel.Signature{})
-	err = signature.Decode(sig64)
-	if err != nil {
-		return false
-	}
-
-	return publicKey.Verify(signature, signingContext)
-}
-
-func (pubKey PubKey) String() string {
-	return fmt.Sprintf("PubKeySr25519{%X}", []byte(pubKey))
-}
-
-// Equals - checks that two public keys are the same time
-// Runs in constant time based on length of the keys.
 func (pubKey PubKey) Equals(other crypto.PubKey) bool {
-	if otherEd, ok := other.(PubKey); ok {
-		return bytes.Equal(pubKey[:], otherEd[:])
+	if otherSr, ok := other.(PubKey); ok {
+		return bytes.Equal(pubKey[:], otherSr[:])
 	}
+
 	return false
+}
+
+func (pubKey PubKey) VerifySignature(msg []byte, sigBytes []byte) bool {
+	var srpk sr25519.PublicKey
+	if err := srpk.UnmarshalBinary(pubKey); err != nil {
+		return false
+	}
+
+	var sig sr25519.Signature
+	if err := sig.UnmarshalBinary(sigBytes); err != nil {
+		return false
+	}
+
+	st := signingCtx.NewTranscriptBytes(msg)
+	return srpk.Verify(st, &sig)
 }
 
 func (pubKey PubKey) Type() string {
 	return KeyType
+}
 
+func (pubKey PubKey) String() string {
+	return fmt.Sprintf("PubKeySr25519{%X}", []byte(pubKey))
 }

--- a/crypto/sr25519/sr25519_test.go
+++ b/crypto/sr25519/sr25519_test.go
@@ -1,6 +1,8 @@
 package sr25519_test
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -71,4 +73,26 @@ func TestBatchSafe(t *testing.T) {
 		expected := (i % 2) == 0
 		require.Equalf(t, expected, ok, "sig[%d] should be %v", i, expected)
 	}
+}
+
+func TestJSON(t *testing.T) {
+	privKey := sr25519.GenPrivKey()
+
+	t.Run("PrivKey", func(t *testing.T) {
+		b, err := json.Marshal(privKey)
+		require.NoError(t, err)
+
+		// b should be the base64 encoded MiniSecretKey, enclosed by doublequotes.
+		b64 := base64.StdEncoding.EncodeToString(privKey.Bytes())
+		b64 = "\"" + b64 + "\""
+		require.Equal(t, []byte(b64), b)
+
+		var privKey2 sr25519.PrivKey
+		err = json.Unmarshal(b, &privKey2)
+		require.NoError(t, err)
+		require.Len(t, privKey2.Bytes(), sr25519.PrivKeySize)
+		require.EqualValues(t, privKey.Bytes(), privKey2.Bytes())
+	})
+
+	// PubKeys are just []byte, so there is no special handling.
 }

--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,11 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/gtank/merlin v0.1.1
-	github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87
 	github.com/lib/pq v1.10.2
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/minio/highwayhash v1.0.2
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	github.com/oasisprotocol/curve25519-voi v0.0.0-20210609091139-0a56a4bca00b
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
@@ -37,8 +37,9 @@ require (
 	github.com/spf13/viper v1.8.0
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tm-db v0.6.4
-	golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9
-	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974
+	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 // indirect
 	google.golang.org/grpc v1.38.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/gtank/merlin v0.1.1
 	github.com/lib/pq v1.10.2
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/minio/highwayhash v1.0.2
@@ -37,8 +36,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/tendermint/tm-db v0.6.4
 	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
-	golang.org/x/net v0.0.0-20201021035429-f5854403a974
-	google.golang.org/genproto v0.0.0-20201119123407-9b1e624d6bc4 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 	google.golang.org/grpc v1.38.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.15
 
 require (
 	github.com/BurntSushi/toml v0.3.1
-	github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782
 	github.com/Masterminds/squirrel v1.5.0
 	github.com/Workiva/go-datastructures v1.0.53
 	github.com/adlio/schema v1.1.13

--- a/go.sum
+++ b/go.sum
@@ -304,7 +304,6 @@ github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFb
 github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
 github.com/gtank/merlin v0.1.1 h1:eQ90iG7K9pOhtereWsmyRJ6RAwcP4tHTDBHXNg+u5is=
 github.com/gtank/merlin v0.1.1/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
-github.com/gtank/ristretto255 v0.1.2 h1:JEqUCPA1NvLq5DwYtuzigd7ss8fwbYay9fi4/5uMzcc=
 github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIvY4OmlYW69o=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=

--- a/go.sum
+++ b/go.sum
@@ -330,8 +330,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87 h1:uUjLpLt6bVvZ72SQc/B4dXcPBw4Vgd7soowdRl52qEM=
-github.com/hdevalence/ed25519consensus v0.0.0-20210204194344-59a8610d2b87/go.mod h1:XGsKKeXxeRr95aEOgipvluMPlgjr7dGlk9ZTWOjcUcg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -425,6 +423,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20210609091139-0a56a4bca00b h1:MKwruh+HeCSKWphkxuzvRzU4QzDkg7yiPkDVV0cDFgI=
+github.com/oasisprotocol/curve25519-voi v0.0.0-20210609091139-0a56a4bca00b/go.mod h1:TLJifjWF6eotcfzDjKZsDqWJ+73Uvj/N85MvVyrvynM=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -644,6 +644,8 @@ golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
 golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/go.sum
+++ b/go.sum
@@ -37,15 +37,11 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-filippo.io/edwards25519 v1.0.0-beta.2 h1:/BZRNzm8N4K4eWfK28dL4yescorxtO7YG1yun8fy+pI=
-filippo.io/edwards25519 v1.0.0-beta.2/go.mod h1:X+pm78QAUPtFLi1z9PYIlS/bdDnvbCOGKtZ+ACWEf7o=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782 h1:lwmjzta2Xu+3rPVY/VeNQj2xfNkyih4CwyRxYg3cpRQ=
-github.com/ChainSafe/go-schnorrkel v0.0.0-20210222182958-bd440c890782/go.mod h1:URdX5+vg25ts3aCh8H5IFZybJYKWhJHYMTnf+ULtoC4=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
@@ -135,8 +131,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
-github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -301,10 +295,6 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/gtank/merlin v0.1.1-0.20191105220539-8318aed1a79f/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
-github.com/gtank/merlin v0.1.1 h1:eQ90iG7K9pOhtereWsmyRJ6RAwcP4tHTDBHXNg+u5is=
-github.com/gtank/merlin v0.1.1/go.mod h1:T86dnYJhcGOh5BjZFCJWTDeTK7XW8uE+E21Cy/bIQ+s=
-github.com/gtank/ristretto255 v0.1.2/go.mod h1:Ph5OpO6c7xKUGROZfWVLiJf9icMDwUeIvY4OmlYW69o=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
@@ -391,8 +381,6 @@ github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzp
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643 h1:hLDRPB66XQT/8+wG9WsDpiCvZf1yKO7sz7scAjSlBa0=
-github.com/mimoo/StrobeGo v0.0.0-20181016162300-f8f6d4d2b643/go.mod h1:43+3pMjjKimDBf5Kr4ZFNGbLql1zKkbImw+fZbw3geM=
 github.com/minio/highwayhash v1.0.2 h1:Aak5U0nElisjDCfPSG79Tgzkn2gl66NxOMspRrKnA/g=
 github.com/minio/highwayhash v1.0.2/go.mod h1:BQskDq+xkJ12lmlUUi7U0M5Swg3EWR+dLTk+kldvVxY=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -637,12 +625,9 @@ golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9 h1:phUcVbl53swtrUN8kQEXFhUxPlIlWyBfKmidCu7P95o=
-golang.org/x/crypto v0.0.0-20201117144127-c1f2f97bffc9/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/internal/p2p/conn/evil_secret_connection_test.go
+++ b/internal/p2p/conn/evil_secret_connection_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/gtank/merlin"
+	"github.com/oasisprotocol/curve25519-voi/primitives/merlin"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/chacha20poly1305"
 
@@ -208,9 +208,7 @@ func (c *evilConn) signChallenge() []byte {
 
 	const challengeSize = 32
 	var challenge [challengeSize]byte
-	challengeSlice := transcript.ExtractBytes(labelSecretConnectionMac, challengeSize)
-
-	copy(challenge[:], challengeSlice[0:challengeSize])
+	transcript.ExtractBytes(challenge[:], labelSecretConnectionMac)
 
 	sendAead, err := chacha20poly1305.New(sendSecret[:])
 	if err != nil {

--- a/internal/p2p/conn/secret_connection.go
+++ b/internal/p2p/conn/secret_connection.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/gtank/merlin"
 	pool "github.com/libp2p/go-buffer-pool"
+	"github.com/oasisprotocol/curve25519-voi/primitives/merlin"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/hkdf"
@@ -38,15 +38,15 @@ const (
 	aeadSizeOverhead = 16 // overhead of poly 1305 authentication tag
 	aeadKeySize      = chacha20poly1305.KeySize
 	aeadNonceSize    = chacha20poly1305.NonceSize
+
+	labelEphemeralLowerPublicKey = "EPHEMERAL_LOWER_PUBLIC_KEY"
+	labelEphemeralUpperPublicKey = "EPHEMERAL_UPPER_PUBLIC_KEY"
+	labelDHSecret                = "DH_SECRET"
+	labelSecretConnectionMac     = "SECRET_CONNECTION_MAC"
 )
 
 var (
 	ErrSmallOrderRemotePubKey = errors.New("detected low order point from remote peer")
-
-	labelEphemeralLowerPublicKey = []byte("EPHEMERAL_LOWER_PUBLIC_KEY")
-	labelEphemeralUpperPublicKey = []byte("EPHEMERAL_UPPER_PUBLIC_KEY")
-	labelDHSecret                = []byte("DH_SECRET")
-	labelSecretConnectionMac     = []byte("SECRET_CONNECTION_MAC")
 
 	secretConnKeyAndChallengeGen = []byte("TENDERMINT_SECRET_CONNECTION_KEY_AND_CHALLENGE_GEN")
 )
@@ -132,9 +132,7 @@ func MakeSecretConnection(conn io.ReadWriteCloser, locPrivKey crypto.PrivKey) (*
 
 	const challengeSize = 32
 	var challenge [challengeSize]byte
-	challengeSlice := transcript.ExtractBytes(labelSecretConnectionMac, challengeSize)
-
-	copy(challenge[:], challengeSlice[0:challengeSize])
+	transcript.ExtractBytes(challenge[:], labelSecretConnectionMac)
 
 	sendAead, err := chacha20poly1305.New(sendSecret[:])
 	if err != nil {

--- a/privval/secret_connection.go
+++ b/privval/secret_connection.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	gogotypes "github.com/gogo/protobuf/types"
-	"github.com/gtank/merlin"
 	pool "github.com/libp2p/go-buffer-pool"
+	"github.com/oasisprotocol/curve25519-voi/primitives/merlin"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/curve25519"
 	"golang.org/x/crypto/hkdf"
@@ -42,15 +42,15 @@ const (
 	aeadSizeOverhead = 16 // overhead of poly 1305 authentication tag
 	aeadKeySize      = chacha20poly1305.KeySize
 	aeadNonceSize    = chacha20poly1305.NonceSize
+
+	labelEphemeralLowerPublicKey = "EPHEMERAL_LOWER_PUBLIC_KEY"
+	labelEphemeralUpperPublicKey = "EPHEMERAL_UPPER_PUBLIC_KEY"
+	labelDHSecret                = "DH_SECRET"
+	labelSecretConnectionMac     = "SECRET_CONNECTION_MAC"
 )
 
 var (
 	ErrSmallOrderRemotePubKey = errors.New("detected low order point from remote peer")
-
-	labelEphemeralLowerPublicKey = []byte("EPHEMERAL_LOWER_PUBLIC_KEY")
-	labelEphemeralUpperPublicKey = []byte("EPHEMERAL_UPPER_PUBLIC_KEY")
-	labelDHSecret                = []byte("DH_SECRET")
-	labelSecretConnectionMac     = []byte("SECRET_CONNECTION_MAC")
 
 	secretConnKeyAndChallengeGen = []byte("TENDERMINT_SECRET_CONNECTION_KEY_AND_CHALLENGE_GEN")
 )
@@ -136,9 +136,7 @@ func MakeSecretConnection(conn io.ReadWriteCloser, locPrivKey crypto.PrivKey) (*
 
 	const challengeSize = 32
 	var challenge [challengeSize]byte
-	challengeSlice := transcript.ExtractBytes(labelSecretConnectionMac, challengeSize)
-
-	copy(challenge[:], challengeSlice[0:challengeSize])
+	transcript.ExtractBytes(challenge[:], labelSecretConnectionMac)
 
 	sendAead, err := chacha20poly1305.New(sendSecret[:])
 	if err != nil {


### PR DESCRIPTION
Can't be bothered disabling turboboost, or running multiple iterations.

```
name                                                  old time/op    new time/op    delta
ValidatorSet_VerifyCommit_Ed25519/valset_size_1-8       58.3µs ± 0%    28.3µs ± 0%  -51.38%
ValidatorSet_VerifyCommit_Ed25519/valset_size_8-8       32.5µs ± 0%    19.9µs ± 0%  -38.58%
ValidatorSet_VerifyCommit_Ed25519/valset_size_64-8      27.5µs ± 0%    17.0µs ± 0%  -38.02%
ValidatorSet_VerifyCommit_Ed25519/valset_size_1024-8    31.7µs ± 0%    13.5µs ± 0%  -57.50%

name                                                  old alloc/op   new alloc/op   delta
ValidatorSet_VerifyCommit_Ed25519/valset_size_1-8       1.00kB ± 0%    1.10kB ± 0%   +9.60%
ValidatorSet_VerifyCommit_Ed25519/valset_size_8-8       4.94kB ± 0%    3.75kB ± 0%  -24.15%
ValidatorSet_VerifyCommit_Ed25519/valset_size_64-8      5.01kB ± 0%    3.66kB ± 0%  -26.86%
ValidatorSet_VerifyCommit_Ed25519/valset_size_1024-8    4.78kB ± 0%    2.25kB ± 0%  -52.90%

name                                                  old allocs/op  new allocs/op  delta
ValidatorSet_VerifyCommit_Ed25519/valset_size_1-8         15.0 ± 0%      18.0 ± 0%  +20.00%
ValidatorSet_VerifyCommit_Ed25519/valset_size_8-8         17.0 ± 0%      17.0 ± 0%    0.00%
ValidatorSet_VerifyCommit_Ed25519/valset_size_64-8        16.0 ± 0%      15.0 ± 0%   -6.25%
ValidatorSet_VerifyCommit_Ed25519/valset_size_1024-8      19.0 ± 0%      16.0 ± 0%  -15.79%
```

TODO:
 * [x] Wait till https://github.com/tendermint/tendermint/pull/6414 is fixed, rebase the integration.
 * [x] Light client should use the improved verification API.
 * [ ] Re-integrate all the oasis specific bits on top of this branch.